### PR TITLE
Bump geckodriver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update                             \
  && apt-get install -y --no-install-recommends \
     ca-certificates curl firefox               \
  && rm -fr /var/lib/apt/lists/*                \
- && curl -L https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz | tar xz -C /usr/local/bin \
+ && curl -L https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz | tar xz -C /usr/local/bin \
  && apt-get purge -y ca-certificates curl
 
 CMD ["geckodriver", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update                             \
  && apt-get install -y --no-install-recommends \
     ca-certificates curl firefox               \
  && rm -fr /var/lib/apt/lists/*                \
- && curl -L https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz | tar xz -C /usr/local/bin \
+ && curl -L https://github.com/mozilla/geckodriver/releases/download/v0.28.0/geckodriver-v0.28.0-linux64.tar.gz | tar xz -C /usr/local/bin \
  && apt-get purge -y ca-certificates curl
 
 CMD ["geckodriver", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ will listen on port 5900.
 
 ## Versions
 
-Currently geckodriver 0.13 is installed along with the latest Firefox package
+Currently geckodriver 0.27 is installed along with the latest Firefox package
 from Debian sid.
 
 ## Customising Firefox profile

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ will listen on port 5900.
 
 ## Versions
 
-Currently geckodriver 0.27 is installed along with the latest Firefox package
+Currently geckodriver 0.28 is installed along with the latest Firefox package
 from Debian sid.
 
 ## Customising Firefox profile


### PR DESCRIPTION
There's been two releases since we last bumped this. This adds two separate commits so they can be independently tagged and built with their respective versions